### PR TITLE
Create reusable success dialog

### DIFF
--- a/frontend/src/components/ui/SuccessDialog.tsx
+++ b/frontend/src/components/ui/SuccessDialog.tsx
@@ -1,0 +1,70 @@
+import { Dialog, DialogTitle, DialogContent, DialogActions, Button, Typography } from '@mui/material';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+import type { SxProps, Theme } from '@mui/material';
+
+interface SuccessDialogProps {
+  open: boolean;
+  onClose: () => void;
+  title: React.ReactNode;
+  question: React.ReactNode;
+  onFinalize: () => void;
+  onAgain: () => void;
+  finalizeText?: string;
+  againText?: string;
+  paperSx?: SxProps<Theme>;
+}
+
+export default function SuccessDialog({
+  open,
+  onClose,
+  title,
+  question,
+  onFinalize,
+  onAgain,
+  finalizeText = 'Finalizar',
+  againText = 'Cadastrar outro',
+  paperSx,
+}: SuccessDialogProps) {
+  return (
+    <Dialog
+      open={open}
+      hideBackdrop={false}
+      onClose={(_, reason) => {
+        if (reason !== 'backdropClick' && reason !== 'escapeKeyDown') {
+          onClose();
+        }
+      }}
+      PaperProps={{
+        sx: {
+          borderRadius: 3,
+          p: 2,
+          maxWidth: 420,
+          ...paperSx,
+        },
+      }}
+    >
+      <DialogTitle sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <CheckCircleOutlineIcon color="success" />
+        <Typography variant="h6" component="span" fontWeight="bold">
+          {title}
+        </Typography>
+      </DialogTitle>
+      <DialogContent>
+        <Typography>{question}</Typography>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button variant="outlined" onClick={onFinalize}>
+          {finalizeText}
+        </Button>
+        <Button
+          variant="contained"
+          onClick={onAgain}
+          autoFocus
+          sx={{ whiteSpace: 'nowrap', minWidth: 160 }}
+        >
+          {againText}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/src/pages/courses/CourseFormPage.tsx
+++ b/frontend/src/pages/courses/CourseFormPage.tsx
@@ -2,15 +2,11 @@ import {
     Box,
     Button,
     Typography,
-    Dialog,
-    DialogTitle,
-    DialogContent,
-    DialogActions,
 } from '@mui/material';
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useSnackbar } from 'notistack';
-import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+import SuccessDialog from '../../components/ui/SuccessDialog';
 import { useParams } from 'react-router-dom';
 import CourseFormFields from './components/formpage/CourseFormFields';
 
@@ -171,50 +167,17 @@ export default function CourseFormPage() {
 
             </Box>
 
-            <Dialog
+            <SuccessDialog
                 open={dialogOpen}
-                hideBackdrop={false}
-                onClose={(_, reason) => {
-                    if (reason !== 'backdropClick' && reason !== 'escapeKeyDown') {
-                        setDialogOpen(false);
-                    }
+                onClose={() => setDialogOpen(false)}
+                title={isEditMode ? 'Curso atualizado com sucesso!' : 'Curso cadastrado com sucesso!'}
+                question="Deseja cadastrar outro curso?"
+                onFinalize={() => navigate('/home/cursos')}
+                onAgain={() => {
+                    handleReset();
+                    setDialogOpen(false);
                 }}
-                PaperProps={{
-                    sx: {
-                        borderRadius: 3,
-                        p: 2,
-                        maxWidth: 420,
-                    },
-                }}
-            >
-                <DialogTitle sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                    <CheckCircleOutlineIcon color="success" />
-                    <Typography variant="h6" component="span" fontWeight="bold">
-                        {isEditMode ? 'Curso atualizado com sucesso!' : 'Curso cadastrado com sucesso!'}
-                    </Typography>
-                </DialogTitle>
-
-                <DialogContent>
-                    <Typography>Deseja cadastrar outro curso?</Typography>
-                </DialogContent>
-
-                <DialogActions sx={{ px: 3, pb: 2 }}>
-                    <Button variant="outlined" onClick={() => navigate('/home/cursos')}>
-                        Finalizar
-                    </Button>
-                    <Button
-                        variant="contained"
-                        onClick={() => {
-                            handleReset();
-                            setDialogOpen(false);
-                        }}
-                        autoFocus
-                        sx={{ whiteSpace: 'nowrap', minWidth: 160 }}
-                    >
-                        Cadastrar outro
-                    </Button>
-                </DialogActions>
-            </Dialog>
+            />
 
 
         </Box>

--- a/frontend/src/pages/disciplines/DisciplinesFormPage.tsx
+++ b/frontend/src/pages/disciplines/DisciplinesFormPage.tsx
@@ -1,16 +1,8 @@
-import {
-  Box,
-  Button,
-  Typography,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
-} from '@mui/material';
+import { Box, Button, Typography } from '@mui/material';
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useSnackbar } from 'notistack';
-import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+import SuccessDialog from '../../components/ui/SuccessDialog';
 import DisciplineFormFields from './components/formpage/DisciplineFormFields';
 
 interface Course {
@@ -166,41 +158,17 @@ export default function DisciplinesFormPage() {
         </Button>
       </Box>
 
-      <Dialog
+      <SuccessDialog
         open={dialogOpen}
-        onClose={(_, reason) => {
-          if (reason !== 'backdropClick' && reason !== 'escapeKeyDown') {
-            setDialogOpen(false);
-          }
+        onClose={() => setDialogOpen(false)}
+        title="Disciplina cadastrada com sucesso!"
+        question="Deseja cadastrar outra disciplina?"
+        onFinalize={() => navigate('/home/disciplinas')}
+        onAgain={() => {
+          handleReset();
+          setDialogOpen(false);
         }}
-        PaperProps={{ sx: { borderRadius: 3, p: 2, maxWidth: 420 } }}
-      >
-        <DialogTitle sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-          <CheckCircleOutlineIcon color="success" />
-          <Typography variant="h6" component="span" fontWeight="bold">
-            Disciplina cadastrada com sucesso!
-          </Typography>
-        </DialogTitle>
-        <DialogContent>
-          <Typography>Deseja cadastrar outra disciplina?</Typography>
-        </DialogContent>
-        <DialogActions sx={{ px: 3, pb: 2 }}>
-          <Button variant="outlined" onClick={() => navigate('/home/disciplinas')}>
-            Finalizar
-          </Button>
-          <Button
-            variant="contained"
-            onClick={() => {
-              handleReset();
-              setDialogOpen(false);
-            }}
-            autoFocus
-            sx={{ whiteSpace: 'nowrap', minWidth: 160 }}
-          >
-            Cadastrar outra
-          </Button>
-        </DialogActions>
-      </Dialog>
+      />
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
- add `SuccessDialog` for success messages
- use `SuccessDialog` in course and discipline form pages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684371b809ac832c8f1f8094be33aeb7