### PR TITLE
Implement PageContainer to reduce layout duplication

### DIFF
--- a/frontend/src/components/ui/PageContainer.tsx
+++ b/frontend/src/components/ui/PageContainer.tsx
@@ -1,0 +1,28 @@
+import type { BoxProps } from '@mui/material';
+import { Box } from '@mui/material';
+import type { ReactNode } from 'react';
+
+interface PageContainerProps extends BoxProps {
+  children: ReactNode;
+}
+
+export default function PageContainer({ children, sx, ...rest }: PageContainerProps) {
+  return (
+    <Box
+      sx={{
+        px: 4,
+        py: 4,
+        width: '100%',
+        boxSizing: 'border-box',
+        minHeight: '100vh',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'flex-start',
+        ...sx,
+      }}
+      {...rest}
+    >
+      {children}
+    </Box>
+  );
+}

--- a/frontend/src/pages/courses/CourseFormPage.tsx
+++ b/frontend/src/pages/courses/CourseFormPage.tsx
@@ -3,6 +3,7 @@ import {
     Button,
     Typography,
 } from '@mui/material';
+import PageContainer from '../../components/ui/PageContainer';
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useSnackbar } from 'notistack';
@@ -121,18 +122,7 @@ export default function CourseFormPage() {
     };
 
     return (
-        <Box
-            sx={{
-                px: 4,
-                py: 4,
-                width: '100%',
-                boxSizing: 'border-box',
-                minHeight: '100vh',
-                display: 'flex',
-                flexDirection: 'column',
-                alignItems: 'flex-start',
-            }}
-        >
+        <PageContainer>
             <Typography variant="h6" fontWeight="bold" gutterBottom>
                 Novo Curso
             </Typography>
@@ -180,6 +170,6 @@ export default function CourseFormPage() {
             />
 
 
-        </Box>
+        </PageContainer>
     );
 }

--- a/frontend/src/pages/courses/CoursesListPage.tsx
+++ b/frontend/src/pages/courses/CoursesListPage.tsx
@@ -14,6 +14,7 @@ import {
   useTheme,
   Fab,
 } from '@mui/material';
+import PageContainer from '../../components/ui/PageContainer';
 import SchoolIcon from '@mui/icons-material/School';
 import AddIcon from '@mui/icons-material/Add';
 import { useEffect, useState } from 'react';
@@ -142,15 +143,9 @@ export default function CoursesListPage() {
   }, [currentPage, searchTerm, statusFilter, limit]);
 
   return (
-    <Box
-
+    <PageContainer
       sx={{
-        px: 4,
-        py: 4,
-        width: '100%',
         maxWidth: `calc(100vw - ${isMobile ? 0 : sidebarWidth}px)`,
-        boxSizing: 'border-box',
-        minHeight: '100vh',
       }}
     >
       <Box display="flex" alignItems="center" gap={1} mb={2}>
@@ -249,7 +244,7 @@ export default function CoursesListPage() {
         confirmColor="error"
       />
 
-    </Box>
+    </PageContainer>
 
 
   );

--- a/frontend/src/pages/disciplines/DisciplinesFormPage.tsx
+++ b/frontend/src/pages/disciplines/DisciplinesFormPage.tsx
@@ -3,6 +3,7 @@ import {
   Button,
   Typography,
 } from '@mui/material';
+import PageContainer from '../../components/ui/PageContainer';
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useSnackbar } from 'notistack';
@@ -134,18 +135,7 @@ export default function DisciplinesFormPage() {
 
 
   return (
-    <Box
-      sx={{
-        px: 4,
-        py: 4,
-        width: '100%',
-        boxSizing: 'border-box',
-        minHeight: '100vh',
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'flex-start',
-      }}
-    >
+    <PageContainer>
       <Typography variant="h6" fontWeight="bold" gutterBottom>
         {isEditMode ? 'Editar Disciplina' : 'Nova Disciplina'}
       </Typography>
@@ -186,6 +176,6 @@ export default function DisciplinesFormPage() {
           setDialogOpen(false);
         }}
       />
-    </Box>
+    </PageContainer>
   );
 }

--- a/frontend/src/pages/disciplines/DisciplinesListPage.tsx
+++ b/frontend/src/pages/disciplines/DisciplinesListPage.tsx
@@ -15,6 +15,7 @@ import {
   Fab,
   TextField,
 } from '@mui/material';
+import PageContainer from '../../components/ui/PageContainer';
 import MenuBookIcon from '@mui/icons-material/MenuBook';
 import AddIcon from '@mui/icons-material/Add';
 import { useEffect, useState } from 'react';
@@ -121,14 +122,9 @@ export default function DisciplinesListPage() {
   }, [currentPage, searchTerm, limit]);
 
   return (
-    <Box
+    <PageContainer
       sx={{
-        px: 4,
-        py: 4,
-        width: '100%',
         maxWidth: `calc(100vw - ${isMobile ? 0 : sidebarWidth}px)`,
-        boxSizing: 'border-box',
-        minHeight: '100vh',
       }}
     >
       <Box display="flex" alignItems="center" gap={1} mb={2}>
@@ -223,6 +219,6 @@ export default function DisciplinesListPage() {
         cancelText="Voltar"
         confirmColor="error"
       />
-    </Box>
+    </PageContainer>
   );
 }

--- a/frontend/src/pages/users/UsersListPage.tsx
+++ b/frontend/src/pages/users/UsersListPage.tsx
@@ -15,6 +15,7 @@ import {
   useMediaQuery,
   useTheme,
 } from '@mui/material';
+import PageContainer from '../../components/ui/PageContainer';
 import PeopleAltIcon from '@mui/icons-material/PeopleAlt';
 import { useEffect, useState } from 'react';
 import { useAuth } from '../../context/AuthContext';
@@ -127,14 +128,9 @@ export default function UsersListPage() {
   }, [currentPage, searchTerm, filters, limit]);
 
   return (
-    <Box
+    <PageContainer
       sx={{
-        px: 4,
-        py: 4,
-        width: '100%',
         maxWidth: `calc(100vw - ${isMobile ? 0 : sidebarWidth}px)`,
-        boxSizing: 'border-box',
-        minHeight: '100vh',
       }}
     >
       <Box display="flex" alignItems="center" gap={1} mb={2}>
@@ -227,6 +223,6 @@ export default function UsersListPage() {
           </Box>
         </>
       )}
-    </Box>
+    </PageContainer>
   );
 }


### PR DESCRIPTION
## Summary
- add `PageContainer` component for a consistent page layout container
- refactor course and discipline form pages to use it
- refactor list pages to reuse the new container

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6844aa8b169c832ca10da68816eaab44