### PR TITLE
Implement Themes API endpoints

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -7,6 +7,7 @@ import { UsersModule } from './users/users.module';
 import { CoursesModule } from './courses/courses.module';
 import { DisciplinesModule } from './disciplines/disciplines.module';
 import { ClassesModule } from './classes/classes.module';
+import { ThemesModule } from './themes/themes.module';
 
 
 @Module({
@@ -17,7 +18,8 @@ import { ClassesModule } from './classes/classes.module';
     UsersModule,
     CoursesModule,
     DisciplinesModule,
-    ClassesModule
+    ClassesModule,
+    ThemesModule
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/themes/dto/create-theme.dto.ts
+++ b/backend/src/themes/dto/create-theme.dto.ts
@@ -1,0 +1,5 @@
+export class CreateThemeDto {
+  title: string;
+  description: string;
+  class_discipline_id: string;
+}

--- a/backend/src/themes/dto/update-theme.dto.ts
+++ b/backend/src/themes/dto/update-theme.dto.ts
@@ -1,0 +1,5 @@
+export class UpdateThemeDto {
+  title?: string;
+  description?: string;
+  class_discipline_id?: string;
+}

--- a/backend/src/themes/themes.controller.ts
+++ b/backend/src/themes/themes.controller.ts
@@ -1,0 +1,29 @@
+import { Body, Controller, Delete, Get, Param, Post, Put } from '@nestjs/common';
+import { ThemesService } from './themes.service';
+import { CreateThemeDto } from './dto/create-theme.dto';
+import { UpdateThemeDto } from './dto/update-theme.dto';
+
+@Controller('themes')
+export class ThemesController {
+  constructor(private readonly themesService: ThemesService) {}
+
+  @Get('by-class-discipline/:id')
+  findByClassDiscipline(@Param('id') id: string) {
+    return this.themesService.findByClassDiscipline(id);
+  }
+
+  @Post()
+  create(@Body() dto: CreateThemeDto) {
+    return this.themesService.createTheme(dto);
+  }
+
+  @Put(':id')
+  update(@Param('id') id: string, @Body() dto: UpdateThemeDto) {
+    return this.themesService.updateTheme(id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.themesService.deleteTheme(id);
+  }
+}

--- a/backend/src/themes/themes.module.ts
+++ b/backend/src/themes/themes.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ThemesController } from './themes.controller';
+import { ThemesService } from './themes.service';
+
+@Module({
+  controllers: [ThemesController],
+  providers: [ThemesService],
+})
+export class ThemesModule {}

--- a/backend/src/themes/themes.service.ts
+++ b/backend/src/themes/themes.service.ts
@@ -1,0 +1,93 @@
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { CreateThemeDto } from './dto/create-theme.dto';
+import { UpdateThemeDto } from './dto/update-theme.dto';
+
+@Injectable()
+export class ThemesService {
+  private supabase: SupabaseClient;
+
+  constructor(private readonly configService: ConfigService) {
+    const supabaseUrl = this.configService.get<string>('SUPABASE_URL');
+    const supabaseKey = this.configService.get<string>('SUPABASE_ANON_KEY');
+
+    if (!supabaseUrl || !supabaseKey) {
+      throw new Error('Supabase URL or Key is not defined');
+    }
+
+    this.supabase = createClient(supabaseUrl, supabaseKey);
+  }
+
+  async findByClassDiscipline(classDisciplineId: string) {
+    const { data, error } = await this.supabase
+      .from('themes')
+      .select('theme_id, title, description')
+      .eq('class_discipline_id', classDisciplineId)
+      .order('title', { ascending: true });
+
+    if (error) {
+      console.error('Erro ao buscar temas:', error.message);
+      throw new InternalServerErrorException('Erro ao buscar temas');
+    }
+
+    return { data: (data || []).map((t) => ({
+      id: t.theme_id,
+      title: t.title,
+      description: t.description,
+    })) };
+  }
+
+  async createTheme(dto: CreateThemeDto) {
+    const { data, error } = await this.supabase
+      .from('themes')
+      .insert({
+        title: dto.title,
+        description: dto.description,
+        class_discipline_id: dto.class_discipline_id,
+      })
+      .select('theme_id, title, description')
+      .single();
+
+    if (error) {
+      console.error('Erro ao criar tema:', error.message);
+      throw new InternalServerErrorException('Erro ao criar tema');
+    }
+
+    return { data: { id: data.theme_id, title: data.title, description: data.description } };
+  }
+
+  async updateTheme(id: string, dto: UpdateThemeDto) {
+    const { data, error } = await this.supabase
+      .from('themes')
+      .update({
+        title: dto.title,
+        description: dto.description,
+        class_discipline_id: dto.class_discipline_id,
+      })
+      .eq('theme_id', id)
+      .select('theme_id, title, description')
+      .single();
+
+    if (error) {
+      console.error('Erro ao atualizar tema:', error.message);
+      throw new InternalServerErrorException('Erro ao atualizar tema');
+    }
+
+    return { data: { id: data.theme_id, title: data.title, description: data.description } };
+  }
+
+  async deleteTheme(id: string) {
+    const { error } = await this.supabase
+      .from('themes')
+      .delete()
+      .eq('theme_id', id);
+
+    if (error) {
+      console.error('Erro ao remover tema:', error.message);
+      throw new InternalServerErrorException('Erro ao remover tema');
+    }
+
+    return { message: 'Tema removido com sucesso' };
+  }
+}


### PR DESCRIPTION
## Summary
- add CRUD endpoints for themes
- wire up the new Themes module in the NestJS backend

## Testing
- `npm run lint` in `backend` *(fails: Cannot find package '@eslint/js')*
- `npm run lint` in `frontend` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6847065f1a00832c97c8c599f50293ad