### PR TITLE
Introduce reusable ActionCell

### DIFF
--- a/frontend/src/components/ui/ActionCell.tsx
+++ b/frontend/src/components/ui/ActionCell.tsx
@@ -1,0 +1,36 @@
+import { TableCell, IconButton, Tooltip } from '@mui/material';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import type { ReactNode } from 'react';
+import type { SxProps, Theme } from '@mui/material';
+
+interface ActionCellProps {
+  onEdit: () => void;
+  onDelete: () => void;
+  editLabel?: ReactNode;
+  deleteLabel?: ReactNode;
+  sx?: SxProps<Theme>;
+}
+
+export default function ActionCell({
+  onEdit,
+  onDelete,
+  editLabel = 'Editar',
+  deleteLabel = 'Excluir',
+  sx,
+}: ActionCellProps) {
+  return (
+    <TableCell align="center" onClick={(e) => e.stopPropagation()} sx={sx}>
+      <Tooltip title={editLabel}>
+        <IconButton onClick={onEdit} size="small">
+          <EditIcon fontSize="small" />
+        </IconButton>
+      </Tooltip>
+      <Tooltip title={deleteLabel}>
+        <IconButton onClick={onDelete} size="small">
+          <DeleteIcon fontSize="small" color="error" />
+        </IconButton>
+      </Tooltip>
+    </TableCell>
+  );
+}

--- a/frontend/src/pages/classes/components/listpage/ClassRow.tsx
+++ b/frontend/src/pages/classes/components/listpage/ClassRow.tsx
@@ -1,7 +1,6 @@
-import { TableRow, TableCell, IconButton, Tooltip } from '@mui/material';
-import EditIcon from '@mui/icons-material/Edit';
-import DeleteIcon from '@mui/icons-material/Delete';
+import { TableRow, TableCell } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
+import ActionCell from '../../../../components/ui/ActionCell';
 
 interface ClassItem {
   class_id: string;
@@ -24,18 +23,10 @@ export default function ClassRow({ item, onEdit, onDelete }: Props) {
       <TableCell>{item.code}</TableCell>
       <TableCell>{item.year}</TableCell>
       <TableCell>{item.semester}</TableCell>
-      <TableCell align="center" onClick={(e) => e.stopPropagation()}>
-        <Tooltip title="Editar">
-          <IconButton onClick={() => onEdit(item.class_id)}>
-            <EditIcon fontSize="small" />
-          </IconButton>
-        </Tooltip>
-        <Tooltip title="Excluir">
-          <IconButton onClick={() => onDelete(item.class_id)}>
-            <DeleteIcon fontSize="small" color="error" />
-          </IconButton>
-        </Tooltip>
-      </TableCell>
+      <ActionCell
+        onEdit={() => onEdit(item.class_id)}
+        onDelete={() => onDelete(item.class_id)}
+      />
     </TableRow>
   );
 }

--- a/frontend/src/pages/courses/components/listpage/CourseRow.tsx
+++ b/frontend/src/pages/courses/components/listpage/CourseRow.tsx
@@ -1,9 +1,6 @@
-import {
-  TableRow, TableCell, IconButton, Tooltip
-} from '@mui/material';
-import EditIcon from '@mui/icons-material/Edit';
-import DeleteIcon from '@mui/icons-material/Delete';
+import { TableRow, TableCell } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
+import ActionCell from '../../../../components/ui/ActionCell';
 
 interface Course {
   course_id: string;
@@ -30,18 +27,10 @@ export default function CourseRow({ course, onEdit, onDelete }: Props) {
       <TableCell>{course.name}</TableCell>
       <TableCell>{course.acronym.toUpperCase()}</TableCell>
       <TableCell align="center">{course.status === 'active' ? '✅' : '❌'}</TableCell>
-      <TableCell align="center" onClick={(e) => e.stopPropagation()}>
-        <Tooltip title="Editar">
-          <IconButton onClick={() => onEdit(course.course_id)}>
-            <EditIcon fontSize="small" />
-          </IconButton>
-        </Tooltip>
-        <Tooltip title="Excluir">
-          <IconButton onClick={() => onDelete(course.course_id)}>
-            <DeleteIcon fontSize="small" color="error" />
-          </IconButton>
-        </Tooltip>
-      </TableCell>
+      <ActionCell
+        onEdit={() => onEdit(course.course_id)}
+        onDelete={() => onDelete(course.course_id)}
+      />
     </TableRow>
   );
 }

--- a/frontend/src/pages/disciplines/components/listpage/DisciplineRow.tsx
+++ b/frontend/src/pages/disciplines/components/listpage/DisciplineRow.tsx
@@ -1,7 +1,6 @@
-import { TableRow, TableCell, IconButton, Tooltip } from '@mui/material';
-import EditIcon from '@mui/icons-material/Edit';
-import DeleteIcon from '@mui/icons-material/Delete';
+import { TableRow, TableCell } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
+import ActionCell from '../../../../components/ui/ActionCell';
 
 interface Discipline {
   discipline_id: string;
@@ -32,22 +31,11 @@ export default function DisciplineRow({ discipline, onEdit, onDelete, isMobile }
       <TableCell sx={{ minWidth: isMobile ? 80 : 140 }}>
         {discipline.workload_hours}h
       </TableCell>
-      <TableCell
-        align="center"
+      <ActionCell
+        onEdit={() => onEdit(discipline.discipline_id)}
+        onDelete={() => onDelete(discipline.discipline_id)}
         sx={{ minWidth: isMobile ? 100 : 160 }}
-        onClick={(e) => e.stopPropagation()} // 🔒 evita propagação do clique da célula
-      >
-        <Tooltip title="Editar">
-          <IconButton onClick={() => onEdit(discipline.discipline_id)}>
-            <EditIcon fontSize="small" />
-          </IconButton>
-        </Tooltip>
-        <Tooltip title="Excluir">
-          <IconButton onClick={() => onDelete(discipline.discipline_id)}>
-            <DeleteIcon fontSize="small" color="error" />
-          </IconButton>
-        </Tooltip>
-      </TableCell>
+      />
     </TableRow>
   );
 }


### PR DESCRIPTION
## Summary
- add `ActionCell` for table edit/delete buttons
- refactor list rows to use new component

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684771434430832cba460c6d364cb437