### PR TITLE
Fix material dialog editing

### DIFF
--- a/frontend/src/pages/themes/ThemesPage.tsx
+++ b/frontend/src/pages/themes/ThemesPage.tsx
@@ -42,7 +42,7 @@ export default function ThemesPage() {
   const [newTitle, setNewTitle] = useState('');
   const [newDescription, setNewDescription] = useState('');
   const [openMaterialDialogFor, setOpenMaterialDialogFor] = useState<string | null>(null);
-  const [newMaterial, setNewMaterial] = useState<Partial<Material> & { file?: File }>({});
+  const [editingMaterial, setEditingMaterial] = useState<Material | null>(null);
   const [materialToDelete, setMaterialToDelete] = useState<string | null>(null);
   const [confirmDialogOpen, setConfirmDialogOpen] = useState(false);
 
@@ -130,10 +130,13 @@ export default function ThemesPage() {
 
         return {
           material_id: m.material_id,
+          theme_id: themeId,
           name: m.title,
           description: m.description,
           type: m.type,
           content: finalUrl,
+          order: m.order,
+          url: finalUrl,
         };
       });
 
@@ -171,8 +174,8 @@ export default function ThemesPage() {
 
 
   const handleEditMaterial = (material: Material) => {
-    setOpenMaterialDialogFor(material.material_id); // ou tema atual
-    setNewMaterial(material); // pré-carrega os campos no dialog
+    setEditingMaterial(material);
+    setOpenMaterialDialogFor(material.theme_id);
   };
 
   const confirmDeleteMaterial = async (materialId: string) => {
@@ -382,12 +385,18 @@ export default function ThemesPage() {
 
       <MaterialFormDialog
         open={!!openMaterialDialogFor}
-        onClose={() => setOpenMaterialDialogFor(null)}
+        onClose={() => {
+          setOpenMaterialDialogFor(null);
+          setEditingMaterial(null);
+        }}
         themeId={openMaterialDialogFor}
         onSuccess={() => {
           if (openMaterialDialogFor) fetchMaterials(openMaterialDialogFor);
           setOpenMaterialDialogFor(null);
+          setEditingMaterial(null);
         }}
+        isEditing={!!editingMaterial}
+        initialData={editingMaterial || undefined}
       />
 
       <ConfirmationDialog

--- a/frontend/src/pages/themes/components/ThemeItem.tsx
+++ b/frontend/src/pages/themes/components/ThemeItem.tsx
@@ -123,7 +123,7 @@ export default function ThemeItem({
                     </Typography>
                   )}
                   <Box mt={1}>
-                    <IconButton size="small" onClick={() => onEditMaterial(m)}>
+                    <IconButton size="small" onClick={() => onEditMaterial({ ...m, theme_id: themeId })}>
                       <Edit fontSize="small" />
                     </IconButton>
                     <IconButton

--- a/frontend/src/types/material.ts
+++ b/frontend/src/types/material.ts
@@ -1,7 +1,9 @@
 export interface Material {
   material_id: string;
+  theme_id: string;
   name: string;
   type: string;
+  order: number;
   url: string;
   description?: string;
   content?: string;


### PR DESCRIPTION
## Summary
- allow MaterialFormDialog to handle editing
- pass data from ThemeItem and ThemesPage when editing a material
- include order and theme in material type and fetching

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react-router-dom')*


------
https://chatgpt.com/codex/tasks/task_e_6849a2750c4c832cb1290c46ca654207